### PR TITLE
fix: add cursor pointer to navbar title link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
       <body>
         <header className="flex justify-between items-center p-4 bg-surface border-b border-border">
           <div className="flex items-center gap-8">
-            <Link href="/" className="text-foreground hover:text-accent transition-colors">
+            <Link href="/" className="text-foreground hover:text-accent transition-colors cursor-pointer">
               <h1 className="text-3xl font-semibold m-0">
                 Shinobi
               </h1>


### PR DESCRIPTION
Make the title link more obvious by adding cursor-pointer class
to indicate that the title is clickable and navigates to homepage.

Closes #3

Generated with [Claude Code](https://claude.ai/code)